### PR TITLE
Correct references to with-entity over with-cache-tree

### DIFF
--- a/src/main/com/wsscode/pathom3/interface/eql.cljc
+++ b/src/main/com/wsscode/pathom3/interface/eql.cljc
@@ -36,11 +36,11 @@
       (p.eql/process (pci/register some-resolvers)
         [:eql :request])
 
-  By default the process will start with a blank entity tree, you can override it by
-  changing sending a entity tree in the environment:
+  By default, processing will start with a blank entity tree. You can override this by
+  sending an entity tree as the second argument in the 3-arity version of this fn:
 
-      (p.eql/process (-> (pci/register some-resolvers)
-                         (p.ent/with-cache-tree {:eql \"initial data\"}))
+      (p.eql/process (pci/register some-resolvers)
+        {:eql \"initial data\"}
         [:eql :request])
 
   For more options around processing check the docs on the connect runner."

--- a/test/com/wsscode/pathom3/entity_tree_test.cljc
+++ b/test/com/wsscode/pathom3/entity_tree_test.cljc
@@ -9,11 +9,11 @@
            {:buz "baz" :a 2 :b 3})
          {:foo "bar", :a 2, :buz "baz", :b 3})))
 
-(deftest with-cache-tree-test
+(deftest with-entity-test
   (is (= @(::p.e/entity-tree* (p.e/with-entity {} {:foo "bar"}))
          {:foo "bar"})))
 
-(deftest swap-entity!-test
+(deftest vswap-entity!-test
   (let [tree* (volatile! {})]
     (is (= (p.e/vswap-entity! {::p.e/entity-tree* tree*}
                               assoc :foo "bar")


### PR DESCRIPTION
It seems `with-cache-tree` was left over when it was renamed to `with-entity` in https://github.com/wilkerlucio/pathom3/commit/8054eb23d19bdbf57e18c2194f72fc6c04f182ac

Also minor correction in the `vswap-entity!` test reference.