### PR TITLE
Generate symbol for static-table-resolver

### DIFF
--- a/src/main/com/wsscode/pathom3/connect/built_in/resolvers.cljc
+++ b/src/main/com/wsscode/pathom3/connect/built_in/resolvers.cljc
@@ -101,16 +101,21 @@
   name to be used to related the data, in this case we use `:song/id` on both, so they
   get connected by it.
   "
-  [resolver-name attr-key table]
-  [::pco/op-name ::p.attr/attribute ::entity-table
-   => ::pco/resolver]
-  (let [output (table-output table)]
-    (pco/resolver resolver-name
-      {::pco/input  [attr-key]
-       ::pco/output output}
-      (fn [_ input]
-        (let [id (get input attr-key)]
-          (get table id))))))
+  ([attr-key table]
+   [::p.attr/attribute ::entity-table
+    => ::pco/resolver]
+   (let [resolver-name (symbol (str (attr-alias-resolver-name attr-key "-static-table")))]
+     (static-table-resolver resolver-name attr-key table)))
+  ([resolver-name attr-key table]
+   [::pco/op-name ::p.attr/attribute ::entity-table
+    => ::pco/resolver]
+   (let [output (table-output table)]
+     (pco/resolver resolver-name
+                   {::pco/input  [attr-key]
+                    ::pco/output output}
+                   (fn [_ input]
+                     (let [id (get input attr-key)]
+                       (get table id)))))))
 
 (>defn attribute-map-resolver
   "This is like the static-table-resolver, but provides a single attribute on each

--- a/src/main/com/wsscode/pathom3/connect/built_in/resolvers.cljc
+++ b/src/main/com/wsscode/pathom3/connect/built_in/resolvers.cljc
@@ -83,10 +83,11 @@
   data for entities using simple Clojure maps. Example:
 
       (def registry
-        [(pbir/static-table-resolver `song-names :song/id
+        [(pbir/static-table-resolver :song/id
            {1 {:song/name \"Marchinha Psicotica de Dr. Soup\"}
             2 {:song/name \"There's Enough\"}})
 
+         ; you can provide a name for the resolver, if so, prefer fully qualified symbols
          (pbir/static-table-resolver `song-analysis :song/id
            {1 {:song/duration 280 :song/tempo 98}
             2 {:song/duration 150 :song/tempo 130}})])

--- a/src/main/com/wsscode/pathom3/connect/built_in/resolvers.cljc
+++ b/src/main/com/wsscode/pathom3/connect/built_in/resolvers.cljc
@@ -112,11 +112,11 @@
     => ::pco/resolver]
    (let [output (table-output table)]
      (pco/resolver resolver-name
-                   {::pco/input  [attr-key]
-                    ::pco/output output}
-                   (fn [_ input]
-                     (let [id (get input attr-key)]
-                       (get table id)))))))
+       {::pco/input  [attr-key]
+        ::pco/output output}
+       (fn [_ input]
+         (let [id (get input attr-key)]
+           (get table id)))))))
 
 (>defn attribute-map-resolver
   "This is like the static-table-resolver, but provides a single attribute on each

--- a/test/com/wsscode/pathom3/connect/built_in/resolvers_test.cljc
+++ b/test/com/wsscode/pathom3/connect/built_in/resolvers_test.cljc
@@ -29,8 +29,8 @@
          {:x 15})))
 
 (deftest map-table-resolver-test
-  (let [resolver (pbir/static-table-resolver 'table ::id {1 {::color "Gray"}
-                                                          2 {::color "Purple"}})
+  (let [resolver (pbir/static-table-resolver ::id {1 {::color "Gray"}
+                                                   2 {::color "Purple"}})
         config   (pco/operation-config resolver)]
     (is (= (resolver {::id 2})
            {::color "Purple"}))


### PR DESCRIPTION
It seems `static-table-resolver` was the only one requiring resolver-name for a symbol, among the other interface fns in this namespace.

I added another 2-arity fn because this is growth and not breakage 😉