### PR TITLE
Fix Eastwood unused-ret-vals linter warnings

### DIFF
--- a/src/main/com/wsscode/pathom3/connect/runner.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner.cljc
@@ -328,7 +328,7 @@
 
     graph))
 
-(defn plan-and-run!
+(>defn plan-and-run!
   [env ast-or-graph entity-tree*]
   [(s/keys) (s/or :ast :edn-query-language.ast/node
                   :graph ::pcp/graph) ::p.ent/entity-tree*


### PR DESCRIPTION
The Eastwood linter complains about an unused-ret-vals in the
`plan-and-run!` function. I believe this function was meant to use
`defn>` instead of the regular `defn`, because it has some specs in
it's definition.