### PR TITLE
Fix batch cache lookup

### DIFF
--- a/src/main/com/wsscode/pathom3/connect/runner.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner.cljc
@@ -404,7 +404,7 @@
                                                                    :available input-shape})))
                             (cond
                               batch?
-                              (if-let [x (find @resolver-cache* [op-name input-data params])]
+                              (if-let [x (p.cache/cache-find resolver-cache* [op-name input-data params])]
                                 (val x)
                                 (if (::unsupported-batch? env)
                                   (invoke-resolver-cached-batch

--- a/src/main/com/wsscode/pathom3/connect/runner/async.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner/async.cljc
@@ -208,7 +208,7 @@
                                                                           :available input-shape})))
                               (cond
                                 batch?
-                                (if-let [x (find @resolver-cache* [op-name input-data params])]
+                                (if-let [x (p.cache/cache-find resolver-cache* [op-name input-data params])]
                                   (val x)
                                   (if (::pcr/unsupported-batch? env)
                                     (invoke-resolver-cached-batch


### PR DESCRIPTION
Closes #44 

This requires the addition of `-cache-find` method to the cache protocol, docs are also updated.