### PR TITLE
Bug priority

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -2,7 +2,7 @@
  ["src/tasks"]
 
  :tasks
- {init
+ {:init
   (do
       (require 'tasks)
       (def source-paths ["src" "test"]))

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
 
  :deps
  {com.fulcrologic/guardrails {:mvn/version "1.1.4"}
-  com.wsscode/cljc-misc      {:mvn/version "2021.04.26"}
+  com.wsscode/cljc-misc      {:mvn/version "2021.05.12"}
   com.wsscode/log            {:git/url "https://github.com/wilkerlucio/log"
                               :sha     "1ac61009b3a57d5d09515ca823556bbe440c292d"}
   funcool/promesa            {:mvn/version "6.0.0"}

--- a/src/main/com/wsscode/pathom3/connect/runner.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner.cljc
@@ -84,7 +84,7 @@
 
 (>def ::taken-paths
   "Set with node-ids for attempted paths in a OR node."
-  ::pcp/node-id-set)
+  (s/coll-of ::pcp/node-id :kind vector?))
 
 (>def ::success-path
   "Path that succeed in a OR node."
@@ -463,7 +463,7 @@
   Returns the paths and their highest priority, in order with the highest priority as
   first. For example:
 
-      [[4 2] [6 1]]
+      [[4 [2 1]] [6 [1]]]
 
   Means the first path is choosing node-id 4, and highest priority is 2."
   [{::pcp/keys [graph] :as env} node-ids]
@@ -473,10 +473,11 @@
                    (->> (pcp/node-successors graph nid)
                         (keep #(pcp/node-with-resolver-config graph env {::pcp/node-id %}))
                         (map #(or (::pco/priority %) 0))
-                        (apply max))])
+                        (sort #(compare %2 %))
+                        vec)])
                 node-ids)]
     (->> paths
-         (sort-by second #(compare %2 %)))))
+         (sort-by second #(coll/vector-compare %2 %)))))
 
 (defn default-choose-path [env _or-node node-ids]
   (-> (priority-sort env node-ids)
@@ -484,7 +485,7 @@
 
 (defn add-taken-path!
   [{::keys [node-run-stats*]} {::pcp/keys [node-id]} taken-path-id]
-  (refs/gswap! node-run-stats* update-in [node-id ::taken-paths] coll/sconj taken-path-id))
+  (refs/gswap! node-run-stats* update-in [node-id ::taken-paths] coll/vconj taken-path-id))
 
 (>defn run-or-node!
   [{::pcp/keys [graph]

--- a/src/main/com/wsscode/pathom3/connect/runner.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner.cljc
@@ -473,6 +473,7 @@
                    (->> (pcp/node-successors graph nid)
                         (keep #(pcp/node-with-resolver-config graph env {::pcp/node-id %}))
                         (map #(or (::pco/priority %) 0))
+                        (distinct)
                         (sort #(compare %2 %))
                         vec)])
                 node-ids)]

--- a/test/com/wsscode/pathom3/connect/runner_test.cljc
+++ b/test/com/wsscode/pathom3/connect/runner_test.cljc
@@ -395,7 +395,7 @@
             [:value]
             (fn [res]
               (mcs/match?
-                {::pcr/taken-paths  #{1}
+                {::pcr/taken-paths  [1]
                  ::pcr/success-path 1}
                 (-> res meta ::pcr/run-stats ::pcr/node-run-stats (get 3)))))))
 
@@ -414,6 +414,30 @@
             {}
             [:value]
             {:value 2}))
+
+      (testing "competing priority, look at next lower."
+        (is (graph-response?
+              (pci/register
+                [(pco/resolver `x
+                   {::pco/output   [:x :y]
+                    ::pco/priority 9}
+                   (fn [_ _]
+                     {:x 1 :y 2}))
+                 (pco/resolver `value1
+                   {::pco/input    [:x]
+                    ::pco/output   [:value]
+                    ::pco/priority 1}
+                   (fn [_ _]
+                     {:value 1}))
+                 (pco/resolver `value2
+                   {::pco/input    [:y]
+                    ::pco/output   [:value]
+                    ::pco/priority 2}
+                   (fn [_ _]
+                     {:value 2}))])
+              {}
+              [:y :value]
+              {:x 1, :y 2, :value 2})))
 
       (testing "distinct inputs"
         (is (graph-response?


### PR DESCRIPTION
After investigation, I notice the algorithm was working as expected, but it only looks at the max value, in this case, the highest was `seed-data` with 99, which appears in both paths:

<img width="559" alt="Screen Shot 2021-05-12 at 21 35 34" src="https://user-images.githubusercontent.com/25736/118060799-fea38780-b369-11eb-990c-2264f535f065.png">

Making both paths the same priority.

I updated the algorithm, so in case of a draw, the algorithm will check the next highest priority of each path.

Closes #48 