### PR TITLE
Issue 52

### DIFF
--- a/test/com/wsscode/pathom3/connect/planner_test.cljc
+++ b/test/com/wsscode/pathom3/connect/planner_test.cljc
@@ -711,7 +711,7 @@
                                                   :index-ast             {:b {:type         :prop,
                                                                               :dispatch-key :b,
                                                                               :key          :b}},
-                                                  :unreachable-paths     {:a {:b {}}, :b {}}}))
+                                                  :unreachable-paths     {:a {}, :b {}}}))
 
     (is (= (compute-run-graph
              (-> {::eql/query          [:b]


### PR DESCRIPTION
Closes #52 

I found the issue to be related to partial cycles. In this case, the planner was being too eager to mark an attribute as unreachable. In those cases, only one path should have failed. I notice the code point making the error was an attempt to mark unreachable when computing nested inputs, but having a second look I believe it's unnecessary, making an easy removal.