### PR TITLE
p.c.r.parallel: use :default instead of Throwable in CLJS

### DIFF
--- a/src/main/com/wsscode/pathom3/connect/runner/parallel.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner/parallel.cljc
@@ -219,7 +219,7 @@
                            (p/catch (fn [e]
                                       (try
                                         (pcr/mark-batch-errors e env batch-op batch-items)
-                                        (catch Throwable _ nil))
+                                        (catch #?(:clj Throwable :cljs :default) _ nil))
                                       {::pcr/node-error e})))
           finish       (time/now-ms)]
 


### PR DESCRIPTION
Quick minor PR -- I pull in Pathom in full client-side as well as server-side, just as a sanity check.

When doing so I noticed that I was seeing warnings, since in a `CLJC` file, one `Throwable / :default` pair was missed and just left as `Throwable`.

This PR just corrects that.