### PR TITLE
Fix Nested optional key throws "All paths from an OR node failed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [NEXT]
+- Fix nexted optional key throws "All paths from an OR node failed" (issue #139)
+
 ## [2022.05.19-alpha]
 - Fix spec issues with mutations
 - Fix async environment on async boundary interface

--- a/src/main/com/wsscode/pathom3/connect/planner.cljc
+++ b/src/main/com/wsscode/pathom3/connect/planner.cljc
@@ -309,8 +309,11 @@
       (if (::run-and node) "AND")
       (if (::run-or node) "OR"))))
 
-(defn attr-optional? [{::keys [index-ast]} attribute]
-  (get-in index-ast [attribute :params :com.wsscode.pathom3.connect.operation/optional?]))
+(defn attr-optional? [{::keys [index-ast]} attribute-kw]
+  (let [attribute (get index-ast attribute-kw)]
+    ;; If the attribute isn't in the index-ast, then it can be considered optional
+    (or (nil? attribute)
+        (get-in attribute [:params ::pco/optional?]))))
 
 (defn add-node-parent [graph node-id node-parent-id]
   (assert node-parent-id "Tried to add after node with nil value")

--- a/test/com/wsscode/pathom3/connect/runner_test.cljc
+++ b/test/com/wsscode/pathom3/connect/runner_test.cljc
@@ -1415,7 +1415,32 @@
                {:out "B"})))])
       {:in "c"}
       [(pco/? :out)]
-      {})))
+      {}))
+
+  (testing "nested multiple options on optional, issue #139"
+    (is
+      (graph-response? (pci/register [(pco/resolver 'one
+                                        {::pco/input  []
+                                         ::pco/output [::one]}
+                                        (fn [_ _] nil))
+
+                                      (pco/resolver 'two-a
+                                        {::pco/input  [::one]
+                                         ::pco/output [::two]}
+                                        (fn [_ _] nil))
+
+                                      (pco/resolver 'two-b
+                                        {::pco/input  [::one]
+                                         ::pco/output [::two]}
+                                        (fn [_ _] nil))
+
+                                      (pco/resolver 'three
+                                        {::pco/input  [::two]
+                                         ::pco/output [::three]}
+                                        (fn [_ _] nil))])
+        {}
+        [(pco/? ::three)]
+        {}))))
 
 (deftest run-graph!-batch-test
   (testing "simple batching"


### PR DESCRIPTION
## Belongs to #139
With this PR, I believe I fix the case where an exception is thrown for a key that's not requested but can't be retrieved (if it's upstream from an optional key). I'm not 100% sure in this fix, however I wanted to submit it to get some initial feedback.

The tests all pass, and I updated a code-base written in pathom3 to point to this fix and all those tests also pass so I'm hopeful the fix is as simple as this.

Thanks as always!

