### PR TITLE
Wrap entity merge async and parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [NEXT]
+- Add support for ::pcr/wrap-merge-attribute hook in async and parallel runners
+
 ## [2022.07.08-alpha]
 - Fix: Exceptions that occur inside `p.a.eql/process` in JVM won't include the entire stacktrace anymore. (issue #142)
 - Add `::p.error/error-data` to datafied error object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [NEXT]
 - Add support for ::pcr/wrap-merge-attribute hook in async and parallel runners
+- Add support for ::pcr/wrap-merge-attribute hook on idents (all runners)
 
 ## [2022.07.08-alpha]
 - Fix: Exceptions that occur inside `p.a.eql/process` in JVM won't include the entire stacktrace anymore. (issue #142)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>com.wsscode</groupId>
   <artifactId>pathom3</artifactId>
-  <version>2022.06.01-alpha</version>
+  <version>2022.07.08-alpha</version>
   <name>pathom3</name>
   <description>A library to unify data sources via attribute modeling in a seamless graph.</description>
   <url>https://github.com/wilkerlucio/pathom3</url>
@@ -18,7 +18,7 @@
     <url>https://github.com/wilkerlucio/pathom3</url>
     <connection>scm:git:git://github.com/wilkerlucio/pathom3.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/wilkerlucio/pathom3.git</developerConnection>
-    <tag>v2022.06.01-alpha</tag>
+    <tag>v2022.07.08-alpha</tag>
   </scm>
   <dependencies>
     <dependency>

--- a/src/main/com/wsscode/pathom3/connect/runner.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner.cljc
@@ -267,7 +267,8 @@
       (if (refs/kw-identical? v ::pco/unknown-value)
         out
         (p.plugin/run-with-plugins env ::wrap-merge-attribute
-          (fn [env m k v] (assoc m k (process-attr-subquery env entity k v)))
+          (fn merge-entity-data--internal [env m k v]
+            (assoc m k (process-attr-subquery env entity k v)))
           env out k v)))
     entity
     new-data))

--- a/src/main/com/wsscode/pathom3/connect/runner.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner.cljc
@@ -288,8 +288,11 @@
   [env idents]
   (doseq [k idents]
     (p.ent/swap-entity! env
-      #(assoc % k (process-attr-subquery env {} k
-                                         (assoc (get % k) (first k) (second k)))))))
+      (fn [entity]
+        (p.plugin/run-with-plugins env ::wrap-merge-attribute
+          (fn process-idents-merge-attr--internal [env m k v]
+            (assoc m k (process-attr-subquery env entity k v)))
+          env {} k (assoc (get entity k) (first k) (second k)))))))
 
 (defn run-next-node!
   "Runs the next node associated with the node, in case it exists."

--- a/src/main/com/wsscode/pathom3/connect/runner/async.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner/async.cljc
@@ -148,10 +148,13 @@
   [env idents]
   (-> (reduce-async
         (fn [_ k]
-          (p/let [sub-value (process-attr-subquery env {} k
-                                                   (-> (get (p.ent/entity env) k)
-                                                       (assoc (first k) (second k))))]
-            (p.ent/swap-entity! env #(assoc % k sub-value))))
+          (p/let [entity  (p.ent/entity env)
+                  entity' (p.plugin/run-with-plugins env ::pcr/wrap-merge-attribute
+                            (fn process-idents-merge-attr--internal [env m k v]
+                              (p/let [sub-value (process-attr-subquery env entity k v)]
+                                (assoc m k sub-value)))
+                            env {} k (assoc (get entity k) (first k) (second k)))]
+            (p.ent/swap-entity! env #(assoc % k (get entity' k)))))
         nil
         idents)
       (p/then (constantly nil))))

--- a/src/main/com/wsscode/pathom3/connect/runner/async.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner/async.cljc
@@ -123,8 +123,11 @@
     (fn [out k v]
       (if (refs/kw-identical? v ::pco/unknown-value)
         out
-        (p/let [v' (process-attr-subquery env entity k v)]
-          (assoc out k v'))))
+        (p.plugin/run-with-plugins env ::pcr/wrap-merge-attribute
+          (fn merge-entity-data--internal [env m k v]
+            (p/let [v' (process-attr-subquery env entity k v)]
+              (assoc m k v')))
+          env out k v)))
     entity
     new-data))
 

--- a/src/main/com/wsscode/pathom3/connect/runner/parallel.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner/parallel.cljc
@@ -152,10 +152,13 @@
   [env idents]
   (-> (reduce-async
         (fn [_ k]
-          (p/let [sub-value (process-attr-subquery env {} k
-                                                   (-> (get (p.ent/entity env) k)
-                                                       (assoc (first k) (second k))))]
-            (p.ent/swap-entity! env #(assoc % k sub-value))))
+          (p/let [entity  (p.ent/entity env)
+                  entity' (p.plugin/run-with-plugins env ::pcr/wrap-merge-attribute
+                            (fn process-idents-merge-attr--internal [env m k v]
+                              (p/let [sub-value (process-attr-subquery env entity k v)]
+                                (assoc m k sub-value)))
+                            env {} k (assoc (get entity k) (first k) (second k)))]
+            (p.ent/swap-entity! env #(assoc % k (get entity' k)))))
         nil
         idents)
       (p/then (constantly nil))))

--- a/src/main/com/wsscode/pathom3/connect/runner/parallel.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner/parallel.cljc
@@ -127,8 +127,11 @@
     (fn [out k v]
       (if (refs/kw-identical? v ::pco/unknown-value)
         out
-        (p/let [v' (process-attr-subquery env entity k v)]
-          (assoc out k v'))))
+        (p.plugin/run-with-plugins env ::pcr/wrap-merge-attribute
+          (fn merge-entity-data--internal [env m k v]
+            (p/let [v' (process-attr-subquery env entity k v)]
+              (assoc m k v')))
+          env out k v)))
     entity
     new-data))
 


### PR DESCRIPTION
Before this patch wrap entity merge only worked in the sync processor.

Also, idents weren't causing this plugin to trigger and they must, with this patch this fix also applies to all runners.