### PR TITLE
Add support for `:or` keyword on `defresolver` and `defmutation` args…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [NEXT]
 - Fix error when user requests `::pcr/attribute-errors` in lenient mode
 - In `process-one` helpers, when the value is collection it gets the run stats from the parent
+- Add support for `:or` keyword on `defresolver` and `defmutation` args, values in `:or` will be flagged as optional
 
 ## [2022.08.29-alpha]
 - Fix ident processing on serial runner

--- a/test/com/wsscode/pathom3/connect/runner_test.cljc
+++ b/test/com/wsscode/pathom3/connect/runner_test.cljc
@@ -238,6 +238,17 @@
           (fn [env inputs]
             (mapv #(resolve env %) inputs))))))
 
+(pco/defresolver optional-in [{:keys [foo bar]
+                               :or   {bar 1}}]
+  {:out (str foo " - " bar)})
+
+(deftest resolver-implicit-optionals
+  (check-all-runners
+    (pci/register optional-in)
+    {:foo 3}
+    [:out]
+    {:out "3 - 1"}))
+
 (pco/defresolver batch-param [env items]
   {::pco/input  [:id]
    ::pco/output [:v]


### PR DESCRIPTION
…, values in `:or` will be flagged as optional