### PR TITLE
Fixes dosctring that does not seem to work

### DIFF
--- a/src/main/com/wsscode/pathom3/connect/operation.cljc
+++ b/src/main/com/wsscode/pathom3/connect/operation.cljc
@@ -153,14 +153,7 @@
   "Helper to create a resolver. A resolver have at least a name, the output definition
   and the resolve function.
 
-  You can create a resolver using a map:
-
-      (resolver
-        {::op-name 'foo
-         ::output  [:foo]
-         ::resolve (fn [env input] ...)})
-
-  Or with the helper syntax:
+  You can create a resolver using the following syntax:
 
       (resolver 'foo {::output [:foo]} (fn [env input] ...))
 
@@ -210,14 +203,7 @@
 (>defn mutation
   "Helper to create a mutation. A mutation must have a name and the mutate function.
 
-  You can create a mutation using a map:
-
-      (mutation
-        {::op-name 'foo
-         ::output  [:foo]
-         ::mutate  (fn [env params] ...)})
-
-  Or with the helper syntax:
+  You can create a mutation using the following syntax:
 
       (mutation 'foo {} (fn [env params] ...))
 


### PR DESCRIPTION
I was trying to create resolvers/mutations using the lower level helpers, and the first syntax mentioned in the docstring does not seem to work. This PR fixes it.