### PR TITLE
`::p.error/missing-output` is now converged to `::p.error/attribute-m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [NEXT]
+- BREAKING: `::p.error/missing-output` is now converged to `::p.error/attribute-missing` (issue #149)
+
 ## [2023.01.31-alpha]
 - Fix map container handling on runner (issue #176)
 - `pf.eql/data->shape` now takes `::pcr/map-container?` into account

--- a/src/main/com/wsscode/pathom3/connect/runner.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner.cljc
@@ -831,7 +831,7 @@
                             " at path " (pr-str path))
                           {:missing        missing
                            ::p.error/phase ::execute
-                           ::p.error/cause ::p.error/missing-output})))))
+                           ::p.error/cause ::p.error/attribute-missing})))))
 
 (defn run-graph-done! [env]
   (check-entity-requires! env)

--- a/src/main/com/wsscode/pathom3/error.cljc
+++ b/src/main/com/wsscode/pathom3/error.cljc
@@ -26,9 +26,7 @@
       ::node-errors
       ::node-exception
 
-      ::plugin-missing-id
-
-      ::missing-output}))
+      ::plugin-missing-id}))
 
 (>def ::lenient-mode? boolean?)
 


### PR DESCRIPTION
Closes #149 