### PR TITLE
Mutation not found error goes through `::pcr/wrap-mutate`, allowing t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - BREAKING: `::p.error/missing-output` is now converged to `::p.error/attribute-missing` (issue #149)
 - BREAKING: Placeholders won't override entity data via params by default (issue #187)
 - New `pbip/placeholder-data-params` plugin to get back the placeholder entity data behavior
+- Mutation not found error goes through `::pcr/wrap-mutate`, allowing the user to capture and transform the not foudn error case
 
 ## [2023.01.31-alpha]
 - Fix map container handling on runner (issue #176)

--- a/src/main/com/wsscode/pathom3/connect/runner/async.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner/async.cljc
@@ -405,7 +405,7 @@
                              (run-foreign-mutation env ast)
                              (p.plugin/run-with-plugins env ::pcr/wrap-mutate
                                #(pco.prot/-mutate mutation %1 (:params %2)) env ast))
-                           (throw (ex-info (str "Mutation " key " not found") {::pco/op-name key}))))
+                           (pcr/invoke-not-found-mutation! env ast key)))
                        (p/catch
                          (fn [e]
                            {::pcr/mutation-error

--- a/src/main/com/wsscode/pathom3/connect/runner/parallel.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner/parallel.cljc
@@ -482,7 +482,7 @@
                              (run-foreign-mutation env ast)
                              (p.plugin/run-with-plugins env ::pcr/wrap-mutate
                                #(pco.prot/-mutate mutation %1 (:params %2)) env ast))
-                           (throw (ex-info (str "Mutation " key " not found") {::pco/op-name key}))))
+                           (pcr/invoke-not-found-mutation! env ast key)))
                        (p/catch
                          (fn [e]
                            {::pcr/mutation-error

--- a/test/com/wsscode/pathom3/connect/runner_test.cljc
+++ b/test/com/wsscode/pathom3/connect/runner_test.cljc
@@ -3185,7 +3185,7 @@
                (fn [env params]
                  (try
                    (mutate env params)
-                   (catch Throwable err
+                   (catch #?(:clj Throwable :cljs :default) err
                      {::pcr/mutation-error (ex-message err)}))))}))
       {}
       '[(foo {})

--- a/test/com/wsscode/pathom3/connect/runner_test.cljc
+++ b/test/com/wsscode/pathom3/connect/runner_test.cljc
@@ -3170,6 +3170,29 @@
             '[{(call {:this "thing"}) [:other]}]
             {'call {::pcr/mutation-error err}}))))
 
+  (testing "wrap-mutation"
+    (check-all-runners
+      (-> {:com.wsscode.pathom3.error/lenient-mode? true}
+          (pci/register
+            [(pco/mutation 'foo2
+               {}
+               (fn [_env _params]
+                 (throw (ex-info "Err" {}))))])
+          (p.plugin/register
+            {::p.plugin/id 'err
+             ::pcr/wrap-mutate
+             (fn [mutate]
+               (fn [env params]
+                 (try
+                   (mutate env params)
+                   (catch Throwable err
+                     {::pcr/mutation-error (ex-message err)}))))}))
+      {}
+      '[(foo {})
+        (foo2 {})]
+      '{foo  {::pcr/mutation-error "Mutation foo not found"},
+        foo2 {::pcr/mutation-error "Err"}}))
+
   (testing "mutation not found"
     (is (graph-response?
           (pci/register


### PR DESCRIPTION
…he user to capture and transform the not foudn error case