### PR TITLE
Return expected false values from process-one helpers rather than nil

### DIFF
--- a/src/main/com/wsscode/pathom3/interface/async/eql.cljc
+++ b/src/main/com/wsscode/pathom3/interface/async/eql.cljc
@@ -103,7 +103,7 @@
           :param ::eql/param-expr)
     => any?]
    (p/let [response (process env entity [attr])]
-     (if-let [val (some-> response first val)]
+     (let [val (some-> response first val)]
        (cond-> val
          (coll? val)
          (vary-meta coll/merge-defaults {::pcr/run-stats (-> response meta ::pcr/run-stats)}))))))

--- a/src/main/com/wsscode/pathom3/interface/eql.cljc
+++ b/src/main/com/wsscode/pathom3/interface/eql.cljc
@@ -104,11 +104,11 @@
           :join ::eql/join
           :param ::eql/param-expr)
     => any?]
-   (let [response (process env entity [attr])]
-     (if-let [val (some-> response first val)]
-       (cond-> val
-         (coll? val)
-         (vary-meta coll/merge-defaults {::pcr/run-stats (-> response meta ::pcr/run-stats)}))))))
+   (let [response (process env entity [attr])
+         val (some-> response first val)]
+     (cond-> val
+       (coll? val)
+       (vary-meta coll/merge-defaults {::pcr/run-stats (-> response meta ::pcr/run-stats)})))))
 
 (>defn satisfy
   "Works like process, but none of the original entity data is filtered out."

--- a/test/com/wsscode/pathom3/interface/async/eql_test.clj
+++ b/test/com/wsscode/pathom3/interface/async/eql_test.clj
@@ -13,7 +13,8 @@
 (def registry
   [geo/full-registry
    (pbir/constantly-resolver :simple "value")
-   (pbir/constantly-fn-resolver :foo ::foo)])
+   (pbir/constantly-fn-resolver :foo ::foo)
+   (pbir/constantly-resolver :false false)])
 
 (defn run-boundary-interface [env request]
   (let [fi (p.a.eql/boundary-interface env)]
@@ -249,7 +250,11 @@
           (meta response)
           => {:com.wsscode.pathom3.connect.runner/run-stats
               {:com.wsscode.pathom3.connect.planner/available-data
-               {:a {}}}})))))
+               {:a {}}}})))
+
+    (testing "returns false"
+      (is (= @(p.a.eql/process-one (pci/register registry) :false)
+             false)))))
 
 (deftest avoid-huge-ex-message
   (let [env (pci/register (pco/resolver `a {::pco/output [:a]}

--- a/test/com/wsscode/pathom3/interface/eql_test.cljc
+++ b/test/com/wsscode/pathom3/interface/eql_test.cljc
@@ -18,7 +18,8 @@
 (def registry
   [geo/full-registry
    coords
-   (pbir/constantly-fn-resolver :foo ::foo)])
+   (pbir/constantly-fn-resolver :foo ::foo)
+   (pbir/constantly-resolver :false false)])
 
 (deftest process-test
   (testing "read"
@@ -133,7 +134,11 @@
           (meta response)
           => {:com.wsscode.pathom3.connect.runner/run-stats
               {:com.wsscode.pathom3.connect.planner/available-data
-               {:a {}}}})))))
+               {:a {}}}})))
+
+    (testing "returns false"
+      (is (= (p.eql/process-one (pci/register registry) :false)
+             false)))))
 
 (defn run-boundary-interface [env request]
   (let [fi (p.eql/boundary-interface env)]


### PR DESCRIPTION
An attempt to fix #195 by eliminating an `if-let` in both `p.eql/process-one` and `p.a.eql/process-one`.

Not sure what the intent of the `if-let`'s is - they seem unnecessary. 