### PR TITLE
include failing key in smart map fetch error

### DIFF
--- a/src/main/com/wsscode/pathom3/interface/smart_map.cljc
+++ b/src/main/com/wsscode/pathom3/interface/smart_map.cljc
@@ -128,7 +128,7 @@
 
          (when-let [error (and (refs/kw-identical? (get env ::error-mode) ::error-mode-loud)
                                (p.error/attribute-error @entity-tree* k))]
-           (throw (ex-info "Smart Map fetch error" error)))
+           (throw (ex-info (str "Smart Map fetch error '" k "'") error)))
 
          (wrap-smart-map env (get @entity-tree* k default-value)))))))
 


### PR DESCRIPTION
Sometimes it comes in handy to find the missing or misspelled key in a smartmap lookup. This prints the key in the exception that gets thrown.