### PR TITLE
docs: readme: update babashka badge target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pathom 3 [![Clojars Project](https://img.shields.io/clojars/v/com.wsscode/pathom3.svg)](https://clojars.org/com.wsscode/pathom3) ![Test](https://github.com/wilkerlucio/pathom3/workflows/Test/badge.svg) [![cljdoc badge](https://cljdoc.xyz/badge/com.wsscode/pathom3)](https://cljdoc.xyz/d/com.wsscode/pathom3/CURRENT) <a href="https://babashka.org" rel="nofollow"><img src="https://github.com/babashka/babashka/raw/master/logo/badge.svg" alt="bb compatible" style="max-width: 100%;"></a>
+# Pathom 3 [![Clojars Project](https://img.shields.io/clojars/v/com.wsscode/pathom3.svg)](https://clojars.org/com.wsscode/pathom3) ![Test](https://github.com/wilkerlucio/pathom3/workflows/Test/badge.svg) [![cljdoc badge](https://cljdoc.org/badge/com.wsscode/pathom3)](https://cljdoc.org/d/com.wsscode/pathom3) [![bb compatible](https://raw.githubusercontent.com/babashka/babashka/master/logo/badge.svg)](https://book.babashka.org#badges)
 
 ![Pathom Logo](repo-resources/pathom-banner-padded.png)
 


### PR DESCRIPTION
New target describes babashka badges

See https://github.com/babashka/babashka/issues/1798

Also
- changed your cljdoc badge to markdown syntax, not sure why it was in html
- noticed your cljdoc badge was broken and fixed (cljdoc.xyz is a retired test server for cljdoc and using CURRENT is not recommended/necessary anymore)