### PR TITLE
Use pcr/cache-key when calling cache-find

### DIFF
--- a/src/main/com/wsscode/pathom3/connect/runner.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner.cljc
@@ -587,7 +587,9 @@
                               missing-check
 
                               batch?
-                              (if-let [x (p.cache/cache-find resolver-cache* [op-name input-data params])]
+                              (if-let [x (p.cache/cache-find
+                                           resolver-cache*
+                                           (cache-key env input-data op-name params))]
                                 (val x)
                                 (if (::unsupported-batch? env)
                                   (invoke-resolver-cached-batch

--- a/src/main/com/wsscode/pathom3/connect/runner/async.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner/async.cljc
@@ -231,7 +231,9 @@
                               missing-check
 
                               batch?
-                              (if-let [x (p.cache/cache-find resolver-cache* [op-name input-data params])]
+                              (if-let [x (p.cache/cache-find
+                                           resolver-cache*
+                                           (pcr/cache-key env input-data op-name params))]
                                 (val x)
                                 (if (::pcr/unsupported-batch? env)
                                   (invoke-resolver-cached-batch

--- a/src/main/com/wsscode/pathom3/connect/runner/parallel.cljc
+++ b/src/main/com/wsscode/pathom3/connect/runner/parallel.cljc
@@ -320,7 +320,9 @@
                              ::pcr/node-error)
                            (cond
                              batch?
-                             (if-let [x (p.cache/cache-find resolver-cache* [op-name input-data params])]
+                             (if-let [x (p.cache/cache-find
+                                          resolver-cache*
+                                          (pcr/cache-key env input-data op-name params))]
                                (val x)
                                (invoke-async-batch
                                  env cache? op-name node cache-store input-data params))


### PR DESCRIPTION
I was getting some `Required attributes missing [...]` errors from a query involving a batch resolver with a custom cache key. Turns out that the three usages of `cache-find` were always using the default cache key instead of checking for a custom cache key first.